### PR TITLE
Fixed rounding issue in db_minutes_to_hhmm

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -815,7 +815,8 @@ function db_now() {
  * @return string representing formatted duration string in hh:mm format.
  */
 function db_minutes_to_hhmm( $p_min = 0 ) {
-	return sprintf( '%02d:%02d', $p_min / 60, $p_min % 60 );
+	$t_min = round($p_min);
+	return sprintf( '%02d:%02d', $t_min / 60, $t_min % 60 );
 }
 
 /**


### PR DESCRIPTION
50 minutes gets stored in the database as (50/60 = 0.83)
When read back, this turns into (0.83*60 = 49.8)

Previous version of db_minutes_to_hhmm would trim down to 49.
New version of db_minutes_to_hhmm rounds it correctly before formatting.